### PR TITLE
Fix issue #32

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -108,6 +108,12 @@ end
 
 -- Events
 
+RegisterNetEvent('QBCore:Client:OnPlayerLoaded', function()
+	QBCore.Functions.TriggerCallback('qb-jewellery:server:getVitrineState', function(result)
+		Config.Locations = result
+	end)
+end)
+
 RegisterNetEvent('qb-jewellery:client:setVitrineState', function(stateType, state, k)
     Config.Locations[k][stateType] = state
 end)

--- a/server/main.lua
+++ b/server/main.lua
@@ -20,6 +20,10 @@ RegisterNetEvent('qb-jewellery:server:setVitrineState', function(stateType, stat
     TriggerClientEvent('qb-jewellery:client:setVitrineState', -1, stateType, state, k)
 end)
 
+QBCore.Functions.CreateCallback('qb-jewellery:server:getVitrineState', function(_, cb)
+	cb(Config.Locations)
+end)
+
 RegisterNetEvent('qb-jewellery:server:vitrineReward', function()
     local src = source
     local Player = QBCore.Functions.GetPlayer(src)


### PR DESCRIPTION
When player reconnect he receive the jewelry status, it is not possible anymore to begin a new one before end of the timer

**Describe Pull request**
First, make sure you've read and are following the contribution guidelines and style guide and your code reflects that.
Write up a clear and concise description of what your pull request adds or fixes and if it's an added feature explain why you think it should be included in the core.

If your PR is to fix an issue mention that issue here

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes/no] (Be honest)
- Does your code fit the style guidelines? [yes/no]
- Does your PR fit the contribution guidelines? [yes/no]
