### PR TITLE
Fixes #35. Added no weapon notification

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -173,6 +173,8 @@ CreateThread(function()
                         action = function()
                             if validWeapon() then
                                 smashVitrine(k)
+                            else
+                                QBCore.Functions.Notify(Lang:t('error.wrong_weapon'), 'error')
                             end
                         end,
                         canInteract = function()


### PR DESCRIPTION
**Describe Pull request**
Added a notification for the weapon check on the qb-target option if the user doesn't have an appropriate weapon in their hands. The notification matches the non-qb-target code.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
