### PR TITLE
No more looping police alerts

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -1,5 +1,6 @@
 local QBCore = exports['qb-core']:GetCoreObject()
 local firstAlarm = false
+local secondAlarm = false
 local smashing = false
 
 -- Functions
@@ -77,7 +78,10 @@ local function smashVitrine(k)
             }, {}, {}, {}, function() -- Done
                 TriggerServerEvent('qb-jewellery:server:vitrineReward', k)
                 TriggerServerEvent('qb-jewellery:server:setTimeout')
+	    if not secondAlarm then
                 TriggerServerEvent('police:server:policeAlert', 'Robbery in progress')
+		secondAlarm = true
+	    end
                 smashing = false
                 TaskPlayAnim(ped, animDict, "exit", 3.0, 3.0, -1, 2, 0, 0, 0, 0)
             end, function() -- Cancel


### PR DESCRIPTION
**Describe Pull request**
Noticed that every time a jewelry case was broken, it would loop the police alert. Not too sure if it was intentional, but I just decided to add it.

If your PR is to fix an issue mention that issue here

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? **YES** (Be honest)
- Does your code fit the style guidelines? **YES**
- Does your PR fit the contribution guidelines? **YES**