### PR TITLE
fix spelling of jewelry

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -55,7 +55,7 @@ local function smashVitrine(k)
         firstAlarm = true
     end
 
-    QBCore.Functions.TriggerCallback('qb-jewellery:server:getCops', function(cops)
+    QBCore.Functions.TriggerCallback('qb-jewelry:server:getCops', function(cops)
         if cops >= Config.RequiredCops then
             local animDict = "missheist_jewel"
             local animName = "smash_case"
@@ -75,17 +75,17 @@ local function smashVitrine(k)
                 disableMouse = false,
                 disableCombat = true,
             }, {}, {}, {}, function() -- Done
-                TriggerServerEvent('qb-jewellery:server:vitrineReward', k)
-                TriggerServerEvent('qb-jewellery:server:setTimeout')
+                TriggerServerEvent('qb-jewelry:server:vitrineReward', k)
+                TriggerServerEvent('qb-jewelry:server:setTimeout')
                 TriggerServerEvent('police:server:policeAlert', 'Robbery in progress')
                 smashing = false
                 TaskPlayAnim(ped, animDict, "exit", 3.0, 3.0, -1, 2, 0, 0, 0, 0)
             end, function() -- Cancel
-                TriggerServerEvent('qb-jewellery:server:setVitrineState', "isBusy", false, k)
+                TriggerServerEvent('qb-jewelry:server:setVitrineState', "isBusy", false, k)
                 smashing = false
                 TaskPlayAnim(ped, animDict, "exit", 3.0, 3.0, -1, 2, 0, 0, 0, 0)
             end)
-            TriggerServerEvent('qb-jewellery:server:setVitrineState', "isBusy", true, k)
+            TriggerServerEvent('qb-jewelry:server:setVitrineState', "isBusy", true, k)
 
             CreateThread(function()
                 while smashing do
@@ -107,19 +107,19 @@ end
 -- Events
 
 RegisterNetEvent('QBCore:Client:OnPlayerLoaded', function()
-	QBCore.Functions.TriggerCallback('qb-jewellery:server:getVitrineState', function(result)
+	QBCore.Functions.TriggerCallback('qb-jewelry:server:getVitrineState', function(result)
 		Config.Locations = result
 	end)
 end)
 
-RegisterNetEvent('qb-jewellery:client:setVitrineState', function(stateType, state, k)
+RegisterNetEvent('qb-jewelry:client:setVitrineState', function(stateType, state, k)
     Config.Locations[k][stateType] = state
 end)
 
 -- Threads
 
 CreateThread(function()
-    local Dealer = AddBlipForCoord(Config.JewelleryLocation["coords"]["x"], Config.JewelleryLocation["coords"]["y"], Config.JewelleryLocation["coords"]["z"])
+    local Dealer = AddBlipForCoord(Config.jewelryLocation["coords"]["x"], Config.jewelryLocation["coords"]["y"], Config.jewelryLocation["coords"]["z"])
     SetBlipSprite (Dealer, 617)
     SetBlipDisplay(Dealer, 4)
     SetBlipScale  (Dealer, 0.7)

--- a/config.lua
+++ b/config.lua
@@ -6,7 +6,7 @@ Config.UseTarget = GetConvar('UseTarget', 'false') == 'true'
 
 Config.Timeout = 30 * (60 * 2000)
 Config.RequiredCops = 2
-Config.JewelleryLocation = {
+Config.jewelryLocation = {
     ["coords"] = vector3(-630.5, -237.13, 38.08),
 }
 

--- a/server/main.lua
+++ b/server/main.lua
@@ -6,7 +6,7 @@ local flags = {}
 
 -- Callback
 
-QBCore.Functions.CreateCallback('qb-jewellery:server:getCops', function(source, cb)
+QBCore.Functions.CreateCallback('qb-jewelry:server:getCops', function(source, cb)
 	local amount = 0
     for _, v in pairs(QBCore.Functions.GetQBPlayers()) do
         if v.PlayerData.job.name == "police" and v.PlayerData.job.onduty then
@@ -17,7 +17,7 @@ QBCore.Functions.CreateCallback('qb-jewellery:server:getCops', function(source, 
     cb(amount)
 end)
 
-QBCore.Functions.CreateCallback('qb-jewellery:server:getVitrineState', function(_, cb)
+QBCore.Functions.CreateCallback('qb-jewelry:server:getVitrineState', function(_, cb)
 	cb(Config.Locations)
 end)
 
@@ -41,14 +41,14 @@ end
 
 -- Events
 
-RegisterNetEvent('qb-jewellery:server:setVitrineState', function(stateType, state, k)
+RegisterNetEvent('qb-jewelry:server:setVitrineState', function(stateType, state, k)
     if stateType == "isBusy" and type(state) == "boolean" and Config.Locations[k] then
         Config.Locations[k][stateType] = state
-        TriggerClientEvent('qb-jewellery:client:setVitrineState', -1, stateType, state, k)
+        TriggerClientEvent('qb-jewelry:client:setVitrineState', -1, stateType, state, k)
     end
 end)
 
-RegisterNetEvent('qb-jewellery:server:vitrineReward', function(vitrineIndex)
+RegisterNetEvent('qb-jewelry:server:vitrineReward', function(vitrineIndex)
     local src = source
     local Player = QBCore.Functions.GetPlayer(src)
     local otherchance = math.random(1, 4)
@@ -56,7 +56,7 @@ RegisterNetEvent('qb-jewellery:server:vitrineReward', function(vitrineIndex)
     local cheating = false
 
     if Config.Locations[vitrineIndex] == nil or Config.Locations[vitrineIndex].isOpened ~= false then
-        exploitBan(src, "Trying to trigger an exploitable event \"qb-jewellery:server:vitrineReward\"")
+        exploitBan(src, "Trying to trigger an exploitable event \"qb-jewelry:server:vitrineReward\"")
         return
     end
     if cachedPoliceAmount[source] == nil then
@@ -74,8 +74,8 @@ RegisterNetEvent('qb-jewellery:server:vitrineReward', function(vitrineIndex)
             if dist <= 25.0 then
                 Config.Locations[vitrineIndex]["isOpened"] = true
                 Config.Locations[vitrineIndex]["isBusy"] = false
-                TriggerClientEvent('qb-jewellery:client:setVitrineState', -1, "isOpened", true, vitrineIndex)
-                TriggerClientEvent('qb-jewellery:client:setVitrineState', -1, "isBusy", false, vitrineIndex)
+                TriggerClientEvent('qb-jewelry:client:setVitrineState', -1, "isOpened", true, vitrineIndex)
+                TriggerClientEvent('qb-jewelry:client:setVitrineState', -1, "isBusy", false, vitrineIndex)
 
                 if otherchance == odd then
                     local item = math.random(1, #Config.VitrineRewards)
@@ -109,25 +109,25 @@ RegisterNetEvent('qb-jewellery:server:vitrineReward', function(vitrineIndex)
             flags[license] = 1
         end
         if flags[license] >= 3 then
-            exploitBan("Getting flagged many times from exploiting the \"qb-jewellery:server:vitrineReward\" event")
+            exploitBan("Getting flagged many times from exploiting the \"qb-jewelry:server:vitrineReward\" event")
         else
             DropPlayer(src, "Exploiting")
         end
     end
 end)
 
-RegisterNetEvent('qb-jewellery:server:setTimeout', function()
+RegisterNetEvent('qb-jewelry:server:setTimeout', function()
     if not timeOut then
         timeOut = true
-        TriggerEvent('qb-scoreboard:server:SetActivityBusy', "jewellery", true)
+        TriggerEvent('qb-scoreboard:server:SetActivityBusy', "jewelry", true)
         Citizen.CreateThread(function()
             Citizen.Wait(Config.Timeout)
 
             for k, _ in pairs(Config.Locations) do
                 Config.Locations[k]["isOpened"] = false
-                TriggerClientEvent('qb-jewellery:client:setVitrineState', -1, 'isOpened', false, k)
-                TriggerClientEvent('qb-jewellery:client:setAlertState', -1, false)
-                TriggerEvent('qb-scoreboard:server:SetActivityBusy', "jewellery", false)
+                TriggerClientEvent('qb-jewelry:client:setVitrineState', -1, 'isOpened', false, k)
+                TriggerClientEvent('qb-jewelry:client:setAlertState', -1, false)
+                TriggerEvent('qb-scoreboard:server:SetActivityBusy', "jewelry", false)
             end
             timeOut = false
         end)


### PR DESCRIPTION
**Describe Pull request**
"Jewelry" is spelled wrong in several places, including the actual name of the resource. This fixes the spelling issues (minus the resource name).

If your PR is to fix an issue mention that issue here

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes] 
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
